### PR TITLE
Fix README deploy button to include template URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Small webapp to sync Elvanto group members to mailing lists on a Google apps dom
 
 This app should run comfortably on Heroku's free tier.
 
-[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://heroku.com/deploy)
+[![Deploy](https://www.herokucdn.com/deploy/button.png)](https://www.heroku.com/deploy/?template=https://github.com/monty5811/elvanto_mail_sync)
 
  - Create credentials on google - you need to create an application with OAuth credentials and a service account
  - Click the push to deploy button


### PR DESCRIPTION
Heroku’s deploy button functionality includes a URL GET parameter linking to the GitHub repository to build the app off of. This pull request simply includes that template parameter in the deploy button on the README.